### PR TITLE
Enables attachment type

### DIFF
--- a/src/components/AnchorMenu/AnchorMenu.tsx
+++ b/src/components/AnchorMenu/AnchorMenu.tsx
@@ -89,7 +89,9 @@ const ExternalNodeBaseComponent = (props: { connectDragSource: ConnectDragSource
             case IQuestionnaireItemType.quantity:
                 return 'ion-calculator';
             case IQuestionnaireItemType.choice:
-                return 'ion-ios-list'
+                return 'ion-ios-list';
+            case IQuestionnaireItemType.attachment:
+                return 'ion-document';
             default:
                 return 'ion-help-circled';
         }
@@ -187,6 +189,7 @@ const AnchorMenu = (props: AnchorMenuProps): JSX.Element => {
                     {createTypeComponent(IQuestionnaireItemType.integer, t('Number'))}
                     {createTypeComponent(IQuestionnaireItemType.choice, t('Multiple Choice'))}
                     {createTypeComponent(IQuestionnaireItemType.string, t('Text'))}
+                    {createTypeComponent(IQuestionnaireItemType.attachment, t('Attachment'))}
                 </div>
                 <SortableTree
                     className="questionnaire-overview__treeview"

--- a/src/components/FormField/FormField.tsx
+++ b/src/components/FormField/FormField.tsx
@@ -19,7 +19,7 @@ const FormField = ({ label, sublabel, isOptional, children }: Props): JSX.Elemen
                     {isOptional && <span className="form-field__optional">{` (${t('Optional')})`}</span>}
                 </label>
             )}
-            {sublabel && <div>{sublabel}</div>}
+            {sublabel && <div style={{textAlign: 'left'}}>{sublabel}</div>}
             {children}
         </div>
     );

--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -99,6 +99,18 @@ const Question = (props: QuestionProps): JSX.Element => {
     const isQuantity = props.item.type === IQuestionnaireItemType.quantity;
     const isDecimalOrQuantity = isDecimal || isQuantity;
 
+    // Adds instructions for the user
+    const instructionType = (): JSX.Element => {
+        if(props.item.type === IQuestionnaireItemType.attachment) {
+            return (
+                <p>
+                    <i>Note:</i> ResearchKitonFHIR maps the 'attachment' type to an <strong>ORKImageCaptureStep</strong> which allows the user to take a photo with the device camera.
+                </p>
+            );
+        }
+        return <></>;
+    }
+
     const respondType = (): JSX.Element => {
         if (
             isItemControlInline(props.item) ||
@@ -149,6 +161,9 @@ const Question = (props: QuestionProps): JSX.Element => {
         <div className="question" id={props.item.linkId}>
             <div className="question-form">
                 <h2 className="question-type-header">{t(getItemDisplayType(props.item))}</h2>
+                <div className="horizontal">
+                    {instructionType()}
+                </div>
                 <div className="horizontal">
                     {/*  <FormField>
                         Markdown not currently supported 

--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -104,7 +104,7 @@ const Question = (props: QuestionProps): JSX.Element => {
         if(props.item.type === IQuestionnaireItemType.attachment) {
             return (
                 <p>
-                    <i>Note:</i> ResearchKitonFHIR maps the 'attachment' type to an <strong>ORKImageCaptureStep</strong> which allows the user to take a photo with the device camera.
+                    <i>Note:</i> <a href="https://github.com/StanfordBDHG/ResearchKitOnFHIR" target="_blank">ResearchKitOnFHIR</a> maps the 'attachment' type to an <strong>ORKImageCaptureStep</strong> which allows the user to take a photo with the device camera.
                 </p>
             );
         }

--- a/src/components/Question/Question.tsx
+++ b/src/components/Question/Question.tsx
@@ -104,7 +104,7 @@ const Question = (props: QuestionProps): JSX.Element => {
         if(props.item.type === IQuestionnaireItemType.attachment) {
             return (
                 <p>
-                    <i>Note:</i> <a href="https://github.com/StanfordBDHG/ResearchKitOnFHIR" target="_blank">ResearchKitOnFHIR</a> maps the 'attachment' type to an <strong>ORKImageCaptureStep</strong> which allows the user to take a photo with the device camera.
+                    <i>Note:</i> <a href="https://github.com/StanfordBDHG/ResearchKitOnFHIR" target="_blank" rel="noopener noreferrer">ResearchKitOnFHIR</a> maps the 'attachment' type to an <strong>ORKImageCaptureStep</strong> which allows the user to take a photo with the device camera.
                 </p>
             );
         }

--- a/src/components/Question/ValidationAnswerTypes/ValidationAnswerTypeAttachment.tsx
+++ b/src/components/Question/ValidationAnswerTypes/ValidationAnswerTypeAttachment.tsx
@@ -21,7 +21,11 @@ const ValidationAnswerTypeAttachment = ({ item }: ValidationAnswerTypeAttachment
     }
 
     return (
-        <FormField label={t('Max file size in MB')}>
+        <>
+        <FormField 
+            label={t('Max file size in MB')}
+            sublabel={t('Note: File size validation is not currently supported by ResearchKitonFHIR.')}
+        >
             <input
                 defaultValue={maxSize}
                 type="number"
@@ -29,6 +33,7 @@ const ValidationAnswerTypeAttachment = ({ item }: ValidationAnswerTypeAttachment
                 onBlur={(e) => updateMaxSize(parseFloat(e.target.value))}
             />
         </FormField>
+        </>
     );
 };
 

--- a/src/components/Question/ValidationAnswerTypes/ValidationAnswerTypeAttachment.tsx
+++ b/src/components/Question/ValidationAnswerTypes/ValidationAnswerTypeAttachment.tsx
@@ -21,7 +21,6 @@ const ValidationAnswerTypeAttachment = ({ item }: ValidationAnswerTypeAttachment
     }
 
     return (
-        <>
         <FormField 
             label={t('Max file size in MB')}
             sublabel={t('Note: File size validation is not currently supported by ResearchKitOnFHIR')}
@@ -33,7 +32,6 @@ const ValidationAnswerTypeAttachment = ({ item }: ValidationAnswerTypeAttachment
                 onBlur={(e) => updateMaxSize(parseFloat(e.target.value))}
             />
         </FormField>
-        </>
     );
 };
 

--- a/src/components/Question/ValidationAnswerTypes/ValidationAnswerTypeAttachment.tsx
+++ b/src/components/Question/ValidationAnswerTypes/ValidationAnswerTypeAttachment.tsx
@@ -24,7 +24,7 @@ const ValidationAnswerTypeAttachment = ({ item }: ValidationAnswerTypeAttachment
         <>
         <FormField 
             label={t('Max file size in MB')}
-            sublabel={t('Note: File size validation is not currently supported by ResearchKitonFHIR.')}
+            sublabel={t('Note: File size validation is not currently supported by ResearchKitOnFHIR')}
         >
             <input
                 defaultValue={maxSize}


### PR DESCRIPTION
<!--

This source file is part of the CardinalKit open-source project

SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Enables attachment type

## :recycle: Current situation & Problem
The FHIR QuestionnaireItem 'attachment' type (binary file upload) is currently disabled because it is not supported by ResearchKitonFHIR in CardinalKit iOS applications. This is because ResearchKit does not have a file upload step that it can be mapped to. However, many projects (including those in CS342) will want to capture images and can use this type to represent an [image capture step](http://researchkit.org/docs/Classes/ORKImageCaptureStep.html). 

Also, CardinalKit Android and other software that renders FHIR questionnaires can handle binary file upload.

## :bulb: Proposed solution
This PR re-enables the 'attachment' type so it can be used by systems that do support this file type. A disclaimer is added stating that ResearchKitOnFHIR will map this type to an ImageCaptureStep and will not apply the Max File Size validation.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

